### PR TITLE
Fix `Add Tracks to a Playlist` api method

### DIFF
--- a/src/clj_spotify/core.clj
+++ b/src/clj_spotify/core.clj
@@ -25,7 +25,7 @@
       (catch Exception e
         {:error {:status "Exception"
                  :message (.getMessage e)
-                 :reponse response}}))
+                 :response response}}))
     {:status (:status response)}))
 
 (defn- build-new-url

--- a/src/clj_spotify/core.clj
+++ b/src/clj_spotify/core.clj
@@ -20,10 +20,12 @@
       (json-string-to-map (:body response))
       (catch java.lang.NullPointerException e
         {:error {:status "NullPointerException"
-                 :message (.getMessage e)}})
+                 :message (.getMessage e)
+                 :response response}})
       (catch Exception e
         {:error {:status "Exception"
-                 :message (.getMessage e)}}))
+                 :message (.getMessage e)
+                 :reponse response}}))
     {:status (:status response)}))
 
 (defn- build-new-url

--- a/src/clj_spotify/core.clj
+++ b/src/clj_spotify/core.clj
@@ -90,7 +90,7 @@
 
 (defn spotify-api-call
   "Returns a function that takes a map m and an optional oauth-token t as arguments."
-  [method endpoint & {:keys [query-params]}]
+  [method endpoint & {:keys [query-params] :or {query-params []}}]
   (fn f
     ([m] (f m nil))
     ([m t]

--- a/test/clj_spotify/core_test.clj
+++ b/test/clj_spotify/core_test.clj
@@ -64,9 +64,10 @@
 
 (def malformed-json-response {:body "{\"test-key\": \"test-value\", \"test-map\" : {\"a\": \"a\"}, \"test-vector\" : [1 2 3], \"test-null\" : }"}) 
 
-(def nullpointer-error-map {:error {:status "NullPointerException", :message nil}}) 
+(defn nullpointer-error-map [response] {:error {:status "NullPointerException", :message nil, :response response}})
 
-(def json-missing-key-error-map {:error {:status "Exception", :message "JSON error (key missing value in object)"}})
+(defn json-missing-key-error-map [response]
+  {:error {:status "Exception", :message "JSON error (key missing value in object)", :response response}})
 
 (def test-url (str sptfy/spotify-api-url "users/user_id/playlists/playlist_id/tracks"))
 (def correct-test-url (str sptfy/spotify-api-url "users/elkalel/playlists/6IIjEBw2BrRXbrSLerA7A6/tracks"))
@@ -78,9 +79,9 @@
   (testing "Conversion from string to clojure map"
     (is (= correct-map (sptfy/response-to-map correctly-formatted-response))))
   (testing "Missing body tag in response."
-    (is (= nullpointer-error-map (sptfy/response-to-map missing-body-tag-response)))) 
+    (is (= (nullpointer-error-map missing-body-tag-response) (sptfy/response-to-map missing-body-tag-response))))
   (testing "Malformed json syntax in string."
-    (is (= json-missing-key-error-map (sptfy/response-to-map malformed-json-response)))))
+    (is (= (json-missing-key-error-map malformed-json-response) (sptfy/response-to-map malformed-json-response)))))
 
 (deftest test-replace-url-values
   (testing "Replace template values in spotify url and compare to correct url."


### PR DESCRIPTION
`Add Tracks to a Playlist` api method (https://developer.spotify.com/web-api/add-tracks-to-playlist/) involves both query and form parameters which led to couple of problems:
- you can't use `:position` parameter as it's going to `:form-params` and should be in `:query-params`
- you can't use even `:uris` parameter, because it should be json encoded list of strings which is not true because all parameters goes through `convert-values` which is ok for `:query-params` but not for `:form-params`.

This PR contains next changes:
- add `response` to error dict in case of error while parsing result json - helped me to find error with `cheshire` dependency
- split `spotify-api-call` method into two parts: one for request preparation and one for making request. Make logic clearer and can be useful for testing.
- support `:query-params` parameter for `spotify-api-call` which indicates which parameters should be in query anyway.
