### PR TITLE
Add `cheshire` as dependency for `clj-http`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/data.codec "0.1.0"]
-                 [clj-http "2.1.0"] ])
+                 [cheshire "5.6.0"]
+                 [clj-http "2.1.0"]])


### PR DESCRIPTION
In the case we send `form-params` as a json encoded body (POST or PUT) using `:content-type :json` ([see here](https://github.com/blmstrm/clj-spotify/blob/master/src/clj_spotify/core.clj#L89)), we get an error from the [clj-http](https://github.com/dakrone/clj-http) library because it requires `cheshire` library.

This is stated in `clj-http`'s [optional-dependencies](https://github.com/dakrone/clj-http#optional-dependencies) doc.

Maybe I'm the only one to encounter this issue but here is how to reproduce it:

``` clojure
(ns test-clj-spotify.core
  (:require [clj-spotify.core :as sptfy])
  (:gen-class :main true))

(defn -main [& args]
  (println (sptfy/create-a-playlist {:user_id "me" :name "clj-spotify test" :public false} "BQBw-JtC..._7GvA")))
```

The result will be:

``` clojure
{:error {:status NullPointerException, :message nil, :response {:type :cheshire-not-loaded, :form-params {:name clj-spotify test, :public false}, :json-opts nil}}}
```

To fix the issue, we can add `cheshire` as a dependency of every project using `clj-spotify` to POST or PUT or we could directly add `cheshire` to this project?
