### PR TITLE
Simplify Basic auth and json parsing in test-utils/spotify-oauth-token

### DIFF
--- a/test/clj_spotify/test_utils.clj
+++ b/test/clj_spotify/test_utils.clj
@@ -1,25 +1,17 @@
 (ns clj-spotify.test-utils
   (:require
             [clojure.data.json :as json]
-            [clojure.data :as data]
             [clj-http.client :as client]
-            [clojure.data.codec.base64 :as b64]
             ))
 
-(def enc-auth-string
-  (str "Basic "
-  (->
-    (str (System/getenv "SPOTIFY_CLIENT_ID") ":" (System/getenv "SPOTIFY_SECRET_TOKEN"))
-    (.getBytes)
-    (b64/encode)
-    (String. "UTF-8"))))
-
-(defonce spotify-oauth-token (->
-                           "https://accounts.spotify.com/api/token" 
-                           (client/post {:form-params {:grant_type "client_credentials"} :headers {:Authorization enc-auth-string}})
-                           :body 
-                           (json/read-str :key-fn keyword)
-                           :access_token))
+(defonce spotify-oauth-token
+  (-> "https://accounts.spotify.com/api/token"
+      (client/post {:form-params {:grant_type "client_credentials"}
+                    :basic-auth [(System/getenv "SPOTIFY_CLIENT_ID")
+                                 (System/getenv "SPOTIFY_SECRET_TOKEN")]
+                    :as :json})
+      :body
+      :access_token))
 
 (defn reset-volatile-vals
   "Function to reset values that change over time such as amount of followers or popularity ranking."


### PR DESCRIPTION
Hi, very small thing: `clj-http` has HTTP Basic auth and json parsing (via cheshire, which clj-spotify is already requiring) built-in, so this can be simplified a bit.

Also, what do you think about exposing a version of this function in the main api for consumers? Something like

```clj
(ns clj-spotify.util
  ...)

(defn get-spotify-token [client-id client-secret]
  ...)
```