### PR TITLE
Add get-access-token function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The map `m` holds both path elements and query parameters.
 Key names and value types in `m` are the same as those found in [Spotify's API Endpoint Reference](https://developer.spotify.com/web-api/endpoint-reference/) for path elements and query parameters. Integer values such as `:limit` and `:offset` can be specified either as integers or strings in `m`. 
 
 ### oauth token `t`
-For a simple method to deal with authentication through the Client Credentials Flow see the `spotify-oauth-token` variable in `core_test.clj`. If you need oauth2 authentication through the Authorization Code Flow see this blog post on how to roll your own: [OAuth2 is easy - illustrated in 50 lines of Clojure](http://leonid.shevtsov.me/en/oauth2-is-easy). 
+For a simple method to obtain an access token through the Client Credentials flow, use `clj-spotify.util/get-access-token`. If you need oauth2 authentication through the Authorization Code Flow (for example, to use endpoints which access private user information), see this blog post on how to roll your own: [OAuth2 is easy - illustrated in 50 lines of Clojure](http://leonid.shevtsov.me/en/oauth2-is-easy).
 
 ### Return values
 clj-spotify returns the data received from the Spotify Web API unaltered but the response will be converted from json to a Clojure map.

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,5 @@
   :plugins [[lein-cloverage "1.0.9"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.6"]
-                 [org.clojure/data.codec "0.1.0"]
                  [cheshire "5.8.0"]
                  [clj-http "3.7.0"]])

--- a/src/clj_spotify/util.clj
+++ b/src/clj_spotify/util.clj
@@ -1,0 +1,14 @@
+(ns clj-spotify.util
+  (:require [clj-http.client :as client]))
+
+(defn get-access-token
+  "Requests an access token from Spotify's API via the Client Credentials flow.
+  The returned token cannot be used for endpoints which access private user information;
+  use the OAuth 2 Authorization Code flow for that."
+  [client-id client-secret]
+  (-> "https://accounts.spotify.com/api/token"
+      (client/post {:form-params {:grant_type "client_credentials"}
+                    :basic-auth [client-id client-secret]
+                    :as :json})
+      :body
+      :access_token))

--- a/test/clj_spotify/test_utils.clj
+++ b/test/clj_spotify/test_utils.clj
@@ -1,17 +1,11 @@
 (ns clj-spotify.test-utils
-  (:require
-            [clojure.data.json :as json]
-            [clj-http.client :as client]
-            ))
+  (:require [clojure.data.json :as json]
+            [clj-spotify.util :refer [get-access-token]]))
 
 (defonce spotify-oauth-token
-  (-> "https://accounts.spotify.com/api/token"
-      (client/post {:form-params {:grant_type "client_credentials"}
-                    :basic-auth [(System/getenv "SPOTIFY_CLIENT_ID")
-                                 (System/getenv "SPOTIFY_SECRET_TOKEN")]
-                    :as :json})
-      :body
-      :access_token))
+  (get-access-token
+    (System/getenv "SPOTIFY_CLIENT_ID")
+    (System/getenv "SPOTIFY_SECRET_TOKEN")))
 
 (defn reset-volatile-vals
   "Function to reset values that change over time such as amount of followers or popularity ranking."


### PR DESCRIPTION
- adds public function `clj-spotify.util/get-access-token`
- removes no-longer-used dependency on `data.codec`