### PR TITLE
revert name for the env-vars

### DIFF
--- a/test/clj_spotify/test_utils.clj
+++ b/test/clj_spotify/test_utils.clj
@@ -4,8 +4,8 @@
 
 (defonce spotify-oauth-token
   (get-access-token
-    (System/getenv "SPOTIFY_OAUTH2_CLIENT_ID")
-    (System/getenv "SPOTIFY_OAUTH2_CLIENT_SECRET")))
+    (System/getenv "SPOTIFY_CLIENT_ID")
+    (System/getenv "SPOTIFY_SECRET_TOKEN")))
 
 (defn reset-volatile-vals
   "Function to reset values that change over time such as amount of followers or popularity ranking."


### PR DESCRIPTION
Well... I broke the travis job when I renamed the env-vars. This should solve it back again.