### PR TITLE
Fix incorrect scope of dev dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,12 +10,11 @@
                  [cheshire "5.10.0"]
                  [clj-http "3.11.0"]]
   :profiles {
-             :dev [:project/dev]
-             :test [:project/dev :profiles/test]
-             :project/dev {
-                           :source-paths ["dev-resources"]
-                           :dependencies [[org.clojure/tools.namespace "1.0.0"]
-                                          [loudmoauth "0.1.3"]
-                                          [ring "1.8.2"]
-                                          [org.clojure/tools.nrepl "0.2.13"]]}
+             :dev {
+                   :source-paths ["dev-resources"]
+                   :dependencies [[org.clojure/tools.namespace "1.0.0"]
+                                  [loudmoauth "0.1.3"]
+                                  [ring "1.8.2"]
+                                  [org.clojure/tools.nrepl "0.2.13"]]}
+             :test [:dev :profiles/test]
              :profiles/test {}})


### PR DESCRIPTION
The library is being published to Clojars with dev dependencies - loudmoauth, ring, clojure tools, see image:

<img width="289" alt="Screenshot 2025-04-24 at 20 01 45" src="https://github.com/user-attachments/assets/9448757b-8654-478d-a122-908109b83c75" />

This PR addresses it, now dev dependencies are tagged with "test" scope, see diff of `lein deps :tree` before and after:
[deps-before.txt](https://github.com/user-attachments/files/19896955/deps-before.txt)
[deps-after.txt](https://github.com/user-attachments/files/19896956/deps-after.txt)

```diff
20,21c20,21
<  [loudmoauth "0.1.3"]
<    [prismatic/schema "1.1.2"]
---
>  [loudmoauth "0.1.3" :scope "test"]
>    [prismatic/schema "1.1.2" :scope "test"]
28,31c28,31
<  [org.clojure/tools.namespace "1.0.0"]
<    [org.clojure/java.classpath "1.0.0"]
<    [org.clojure/tools.reader "1.3.2"]
<  [org.clojure/tools.nrepl "0.2.13"]
---
>  [org.clojure/tools.namespace "1.0.0" :scope "test"]
>    [org.clojure/java.classpath "1.0.0" :scope "test"]
>    [org.clojure/tools.reader "1.3.2" :scope "test"]
>  [org.clojure/tools.nrepl "0.2.13" :scope "test"]
33,49c33,49
<  [ring "1.8.2"]
<    [ring/ring-core "1.8.2"]
<      [commons-fileupload "1.4"]
<      [crypto-equality "1.0.0"]
<      [crypto-random "1.2.0"]
<      [ring/ring-codec "1.1.2"]
<    [ring/ring-devel "1.8.2"]
<      [clj-stacktrace "0.2.8"]
<      [hiccup "1.0.5"]
<      [ns-tracker "0.4.0"]
<    [ring/ring-jetty-adapter "1.8.2"]
<      [org.eclipse.jetty/jetty-server "9.4.31.v20200723"]
<        [javax.servlet/javax.servlet-api "3.1.0"]
<        [org.eclipse.jetty/jetty-http "9.4.31.v20200723"]
<          [org.eclipse.jetty/jetty-util "9.4.31.v20200723"]
<        [org.eclipse.jetty/jetty-io "9.4.31.v20200723"]
<    [ring/ring-servlet "1.8.2"]
---
>  [ring "1.8.2" :scope "test"]
>    [ring/ring-core "1.8.2" :scope "test"]
>      [commons-fileupload "1.4" :scope "test"]
>      [crypto-equality "1.0.0" :scope "test"]
>      [crypto-random "1.2.0" :scope "test"]
>      [ring/ring-codec "1.1.2" :scope "test"]
>    [ring/ring-devel "1.8.2" :scope "test"]
>      [clj-stacktrace "0.2.8" :scope "test"]
>      [hiccup "1.0.5" :scope "test"]
>      [ns-tracker "0.4.0" :scope "test"]
>    [ring/ring-jetty-adapter "1.8.2" :scope "test"]
>      [org.eclipse.jetty/jetty-server "9.4.31.v20200723" :scope "test"]
>        [javax.servlet/javax.servlet-api "3.1.0" :scope "test"]
>        [org.eclipse.jetty/jetty-http "9.4.31.v20200723" :scope "test"]
>          [org.eclipse.jetty/jetty-util "9.4.31.v20200723" :scope "test"]
>        [org.eclipse.jetty/jetty-io "9.4.31.v20200723" :scope "test"]
>    [ring/ring-servlet "1.8.2" :scope "test"]
```