### PR TITLE
Fix tests

### DIFF
--- a/test/clj_spotify/core_test.clj
+++ b/test/clj_spotify/core_test.clj
@@ -19,7 +19,10 @@
   (testing "Conversion from string to clojure map"
     (is (= tf/correct-map (sptfy/response-to-map tf/correctly-formatted-response))))
   (testing "Missing body tag in response."
-    (is (= (tf/nullpointer-error-map tf/missing-body-tag-response) (sptfy/response-to-map tf/missing-body-tag-response))))
+    (let [actual (sptfy/response-to-map tf/missing-body-tag-response)]
+      (is (or (= (tf/nullpointer-error-map tf/missing-body-tag-response) actual)
+              ;; Java 14 and above have extended error messages for NPE
+              (= (tf/nullpointer-error-map tf/missing-body-tag-response "Cannot invoke \"String.length()\" because \"s\" is null") actual)))))
   (testing "Malformed json syntax in string."
     (is (= (tf/json-missing-key-error-map tf/malformed-json-response) (sptfy/response-to-map tf/malformed-json-response)))))
 

--- a/test/clj_spotify/core_test.clj
+++ b/test/clj_spotify/core_test.clj
@@ -69,14 +69,6 @@
   (testing "Get spotify information about an artists top tracks, due to ever changing data, only verify a status 200 response."
     (is  (= 200 (:status (meta (sptfy/get-an-artists-top-tracks {:id "0TnOYISbd1XYRBk9myaseg" :country "ES" } util/spotify-oauth-token)))))))
 
-(deftest test-get-an-artists-related-artists
-  (testing "Get spotify information about similar artists, due to ever changing data, only verify a status 200 response."
-    (is (= 200 (:status (meta (sptfy/get-an-artists-related-artists {:id "5ZKMPRDHc7qElVJFh3uRqB"} util/spotify-oauth-token)))))))
-
-(deftest test-get-a-list-of-featured-playlists
-  (testing "Get a list of spotify featured playlists, due to the data changing according to the time of day, only verify status 200 in response."
-    (is (= 200 (:status (meta (sptfy/get-a-list-of-featured-playlists {:country "US" :timestamp "2014-10-23T07:00:00"}  util/spotify-oauth-token)))))))
-
 (deftest test-get-a-list-of-new-releases
   (testing "Get a list of new releases, due to ever changing data, only verify a status 200 response."
     (is (= 200 (:status (meta (sptfy/get-a-list-of-new-releases {:country "SE" :limit 2} util/spotify-oauth-token)))))))
@@ -88,10 +80,6 @@
 (deftest test-get-a-category
   (testing "Get a spotify category and verify the json data to be equal to test data in category.json"
     (generate-test ( sptfy/get-a-category {:category_id "dinner" :locale "sv_SE" :country "SE"}  util/spotify-oauth-token) tf/category-file)))
-
-(deftest test-get-a-categorys-playlists
-  (testing "Get a spotify category's playlist, due to ever changing data, only verify a status 200 response."
-    (is (= 200 (:status (meta (sptfy/get-a-categorys-playlists {:category_id "dinner" :country "SE" :limit 10 :offset 5} util/spotify-oauth-token)))))))
 
 (deftest test-get-a-playlist
   (testing "Get a spotify playlist and verify the json data to be equal to test data in user-playlist.json"

--- a/test/clj_spotify/test-data/get-a-track.json
+++ b/test/clj_spotify/test-data/get-a-track.json
@@ -60,6 +60,5 @@
   "track_number" : 1,
   "type" : "track",
   "uri" : "spotify:track:1zHlj4dQ8ZAtrayhuDDmkY",
-  "is_local" : 0,
-  "available_markets" : 0
+  "is_local" : 0
 }

--- a/test/clj_spotify/test_fixtures.clj
+++ b/test/clj_spotify/test_fixtures.clj
@@ -34,7 +34,9 @@
 
 (def malformed-json-response {:body "{\"test-key\": \"test-value\", \"test-map\" : {\"a\": \"a\"}, \"test-vector\" : [1 2 3], \"test-null\" : }"}) 
 
-(defn nullpointer-error-map [response] {:error {:status "NullPointerException", :message nil, :response response}})
+(defn nullpointer-error-map
+  ([response] (nullpointer-error-map response nil))
+  ([response message] {:error {:status "NullPointerException", :message message, :response response}}))
 
 (defn json-missing-key-error-map [response]
   {:error {:status "Exception", :message "JSON error (key missing value in object)", :response response}})


### PR DESCRIPTION
* Fixes `test-get-a-track` - API no longer returns "available_markets" when market is specified in the request
* Fixes `test-response-to-map` - was not passing on newer versions of Java because of the [Detailed Message in NullPointerExceptions](https://openjdk.org/jeps/358)
* Removes tests for deprecated methods, that are no longer available for newer client applications. Related to https://github.com/blmstrm/clj-spotify/issues/18 . Methods are still in place, tests are removed because there's no way to check whether they work correctly or not with my Spotify application.